### PR TITLE
Update to 0.0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,9 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# pycharm idea files
+.idea
+
+# mac files
+.DS_STORE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM ubuntu:xenial
+FROM continuumio/miniconda:latest
 
-RUN apt-get update -y && apt-get install -y software-properties-common
-RUN add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable && apt-get update -y && apt-get install -y --no-install-recommends \
-    gdal-bin \
-    python-pip \
-    python-setuptools
-    
-RUN pip install glob2
+# create the conda environment
+RUN mkdir /helper
+COPY ./environment.yml /helper
+RUN conda env create -f /helper/environment.yml
 
-ADD task.py /task.py
-
-CMD python /task.py
+# move the scripts over
+RUN mkdir /scripts
+COPY task.py /scripts/task.py
+SHELL ["/bin/bash", "-c"]
+RUN echo "source activate gdalenv" > ~/.bashrc
+ENV PATH /opt/conda/envs/gdalenv/bin:$PATH

--- a/docker_test.md
+++ b/docker_test.md
@@ -1,0 +1,13 @@
+For testing that the Docker container behaves as expected before deploying as a GBDX Task:
+
+Set LOCAL_PATH env var
+`LOCAL_PATH=$(pwd)`
+
+To test a command that should succeed:
+`docker run --rm -v $LOCAL_PATH/sample_input:/mnt/work/input -it mgleason/gdal-cli-multiplex`
+
+Or, to test a command that should fail:
+`docker run --rm -v $LOCAL_PATH/sample_input_error:/mnt/work/input -it mgleason/gdal-cli-multiplex`
+
+Either way, once the container starts, run:
+`python /scripts/task.py`

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,11 @@
+# environment.yml
+name: gdalenv
+channels: !!python/tuple
+- !!python/unicode
+  'conda-forge'
+- !!python/unicode
+  'defaults'
+dependencies:
+- conda-forge::python=3.6.6
+- conda-forge::click>=7.0,<8.0
+- conda-forge::gdal>=2.4.0,<2.5.0

--- a/sample_input/ports.json
+++ b/sample_input/ports.json
@@ -1,0 +1,3 @@
+{
+  "command": "gdalinfo --version"
+}

--- a/sample_input_error/ports.json
+++ b/sample_input_error/ports.json
@@ -1,0 +1,3 @@
+{
+  "command": "gdalinfo"
+}

--- a/task.py
+++ b/task.py
@@ -1,4 +1,6 @@
-import os, subprocess, json, glob2
+import subprocess
+import json
+
 outdir = '/mnt/work/output/'
 indir = '/mnt/work/input/'
 
@@ -6,10 +8,23 @@ input_data = json.load(open('/mnt/work/input/ports.json'))
 
 command = input_data['command']
 
-command = command.replace('$indir',indir)
-command = command.replace('$outdir',outdir)
-print command
+command = command.replace('$indir', indir)
+command = command.replace('$outdir', outdir)
+
+print("Running command: ")
+print(command)
+print('\n')
+
 proc = subprocess.Popen([command], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 out, err = proc.communicate()
 status = proc.returncode
-print out
+
+print(out.decode())
+print('\n')
+
+if status == 0:
+    print("SUCCESS: Execution of input command completed successfully.")
+else:
+    print("ERROR: Execution of input command failed.")
+    print(err.decode())
+

--- a/task_definition.json
+++ b/task_definition.json
@@ -2,12 +2,13 @@
     "containerDescriptors": [
         {
             "type": "DOCKER",
+            "command": "python /scripts/task.py",
             "properties": {
-                "image": "nricklin/gdal-multiplex-task:latest"
+                "image": "mgleason/gdal-multiplex-task:latest"
             }
         }
     ],
-    "description": "A task for running arbitrary gdal (version 2.2.2) commands with bash on the commandline interface.  It executes a single command, specified via string port input.",
+    "description": "A task for running arbitrary gdal (version 2.4.0) commands with bash on the commandline interface.  It executes a single command, specified via string port input.",
     "inputPortDescriptors": [
         {
             "required": true,
@@ -23,7 +24,7 @@
             "multiplex": true
         }
     ],
-    "version": "0.0.2",
+    "version": "0.0.3",
     "outputPortDescriptors": [
         {
             "description": "Output data directory",
@@ -38,5 +39,5 @@
         "timeout": 7200
     },
     "name": "gdal-cli-multiplex",
-    "taskOwnerEmail": "nricklin@digitalglobe.com"
+    "taskOwnerEmail": "michael.gleason@digitalglobe.com"
 }

--- a/task_definition.json
+++ b/task_definition.json
@@ -4,7 +4,7 @@
             "type": "DOCKER",
             "command": "python /scripts/task.py",
             "properties": {
-                "image": "mgleason/gdal-multiplex-task:latest"
+                "image": "mgleason/gdal-cli-multiplex:latest"
             }
         }
     ],


### PR DESCRIPTION
Includes the following major changes:
- update to Python 3
- switched dockerfile to use miniconda image as a base
- update to gdal 2.4.0
- includes gdal python bindings (which were missing from v0.0.2 but available in the original v0.0.1). this enables use of python-based GDAL CLIs like `gdal_calc.py`
- refactor/cleanup of `task.py` for better messaging, esp. around errors